### PR TITLE
Update rename.py

### DIFF
--- a/core/management/commands/rename.py
+++ b/core/management/commands/rename.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
 
         # logic for renaming the files
 
-        files_to_rename = [f'{current_project_name}/settings.py',
+        files_to_rename = [f'{current_project_name}/settings/base.py',
                            f'{current_project_name}/wsgi.py', 'manage.py']
 
         for f in files_to_rename:


### PR DESCRIPTION
"python manage.py rename oldname newname" throws an error because it cannot find "oldname/settings.py". Should be looking for "oldname/settings/base.py".